### PR TITLE
Remove the Refresh Status as it's unstable

### DIFF
--- a/flask-backend/src/main_server.py
+++ b/flask-backend/src/main_server.py
@@ -49,8 +49,6 @@ CORS(app)
 @app.route("/")
 def my_index():
     template = render_template("index.html")
-    print(template)
-    print("localhost" in template)
     return template
 
 

--- a/flask-backend/src/process_migrate_config.py
+++ b/flask-backend/src/process_migrate_config.py
@@ -35,7 +35,7 @@ ACTION_UPDATE = "Update"
 ACTION_IDENTICAL = "Identical"
 ACTION_DONE = "Identical"
 ACTION_PREEMPTIVE = "Preemptive"
-ACTION_REFRESH = "Refresh"
+# ACTION_REFRESH = "Refresh"
 ACTION_ERROR = "Error"
 
 ACTION_MAP = {
@@ -45,7 +45,7 @@ ACTION_MAP = {
     ACTION_IDENTICAL: "I",
     ACTION_DONE: "I",
     ACTION_PREEMPTIVE: "P",
-    ACTION_REFRESH: "R",
+    # ACTION_REFRESH: "R",
     ACTION_ERROR: "E",
 }
 

--- a/flask-backend/src/tenant.py
+++ b/flask-backend/src/tenant.py
@@ -12,16 +12,35 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import dirs
 import json
+import time
+
+import dirs
+
+MAX_RETRIES = 5
 
 
 def load_tenant_list():
+    retry_count = 0
+    tenant_list = {}
+    while retry_count < MAX_RETRIES:
+        try:
+            tenant_list = _load_tenant_list()
+            break
+        except Exception as e:
+            retry_count += 1
+            time.sleep(1)
 
+    return tenant_list
+
+
+def _load_tenant_list():
     tenant_list = {}
 
     try:
-        with open(dirs.get_tenant_list_dir() + '/list.json', 'r', encoding='UTF-8') as file_tenant_list:
+        with open(
+            dirs.get_tenant_list_dir() + "/list.json", "r", encoding="UTF-8"
+        ) as file_tenant_list:
             tenant_list = json.load(file_tenant_list)
     except FileNotFoundError as e:
         save_tenant_list(tenant_list)
@@ -30,15 +49,15 @@ def load_tenant_list():
 
 
 def load_tenant(key):
-
     tenant_list = load_tenant_list()
 
-    tenant_data = tenant_list['tenants'][key]
+    tenant_data = tenant_list["tenants"][key]
 
     return tenant_data
 
 
 def save_tenant_list(payload):
-
-    with open(dirs.get_tenant_list_dir() + '/list.json', 'w', encoding='UTF-8') as file_tenant_list:
+    with open(
+        dirs.get_tenant_list_dir() + "/list.json", "w", encoding="UTF-8"
+    ) as file_tenant_list:
         file_tenant_list.write(json.dumps(payload))

--- a/flask-backend/src/terraform_ui_util.py
+++ b/flask-backend/src/terraform_ui_util.py
@@ -132,7 +132,7 @@ def create_dict_from_terraform_log(terraform_log, terraform_log_cleaned):
 
     log_dict["modules"] = modules_dict
     log_dict["other_lines"] = other_lines
-    
+
     log_dict = compile_stats(log_dict)
 
     return log_dict
@@ -142,12 +142,10 @@ def compile_stats(log_dict):
     overall_stats = {}
 
     for _, module in log_dict["modules"].items():
-
         for _, resource in module.items():
             status_code = resource["action_code"]
 
             overall_stats = terraform_local.add_to_stats(overall_stats, status_code)
-
 
     log_dict["stats"] = overall_stats
 
@@ -167,7 +165,13 @@ def extract_tf_module(module_lines, modules_dict, first_line_cleaned, is_error):
     elif first_line_cleaned.endswith("will be destroyed"):
         action = process_migrate_config.ACTION_DELETE
     elif first_line_cleaned.endswith("has changed"):
-        action = process_migrate_config.ACTION_REFRESH
+        action = process_migrate_config.ACTION_IDENTICAL
+        # action = process_migrate_config.ACTION_REFR
+
+        # Technically, this would mean Refresh state.
+        # But sometimes a subsequent terraform plan will not show differences
+        # These would be APIs on the Dynatrace clusters that return un-sorted lists, where the order can and will change at some point
+        # So since Refresh also means Done for the migration purpose, they will be tagged as Identical/DoneESH
     elif REFRESH_STATE_LABEL in first_line_cleaned:
         action = process_migrate_config.ACTION_IDENTICAL
     elif CREATING_LABEL in first_line_cleaned:

--- a/react-frontend/src/App.js
+++ b/react-frontend/src/App.js
@@ -16,9 +16,9 @@ limitations under the License.
 import './App.css';
 import React from 'react';
 import ContextMenu from './menu/ContextMenu';
-import TabPanelMain from './navigation/TabPanelMain';
 import AppContextLoad from './context/components/AppContextLoad';
 import AppContext from './context/components/AppContext';
+import { MainPage } from './navigation/MainPage';
 //"@dynatrace/openkit-js": "^1.3.0",     <-- package.json
 //import './dynatrace/openkit';
 
@@ -28,7 +28,7 @@ function App() {
       <AppContext>
         <AppContextLoad>
           <ContextMenu>
-            <TabPanelMain />
+            <MainPage />
           </ContextMenu>
         </AppContextLoad>
       </AppContext>

--- a/react-frontend/src/backend/useEnhancedBackend.js
+++ b/react-frontend/src/backend/useEnhancedBackend.js
@@ -61,18 +61,18 @@ export function useEnhancedBackendFunctions(completeSearchParams, payloadTerrafo
     const enhancedBackendFunctions = useMemo(() => {
 
         const functions = {
-            "backendGet": (api_method, searchParams, thenFunction) => {
+            "backendGet": (api_method, searchParams, thenFunction, catchFunction) => {
                 const completedSearchParams = completeSearchParams(api_method, searchParams)
-                return backendGet(api_method, completedSearchParams, thenFunction)
+                return backendGet(api_method, completedSearchParams, thenFunction, catchFunction)
             },
-            "backendPost": (api_method, payload, searchParams, thenFunction) => {
+            "backendPost": (api_method, payload, searchParams, thenFunction, catchFunction) => {
                 const completedSearchParams = completeSearchParams(api_method, searchParams)
-                return backendPost(api_method, payloadTerraform, completedSearchParams, thenFunction)
+                return backendPost(api_method, payloadTerraform, completedSearchParams, thenFunction, catchFunction)
 
             },
-            "backendDelete": (api_method, payload, searchParams, thenFunction) => {
+            "backendDelete": (api_method, payload, searchParams, thenFunction, catchFunction) => {
                 const completedSearchParams = completeSearchParams(api_method, searchParams)
-                return backendDelete(api_method, payload, completedSearchParams, thenFunction)
+                return backendDelete(api_method, payload, completedSearchParams, thenFunction, catchFunction)
 
             },
         }

--- a/react-frontend/src/context/ExecutionContext.js
+++ b/react-frontend/src/context/ExecutionContext.js
@@ -84,7 +84,7 @@ function reducer(state, action) {
 }
 
 function initState() {
-    return { enableDashboards: false, enableOmitDestroy: false }
+    return { enableDashboards: false, enableOmitDestroy: false, firstTimeUser: true, advancedMode: false }
 }
 
 export function useExecutionOptionsContextReducer() {
@@ -108,12 +108,14 @@ export function useExecutionOptionsStateValue() {
 
     const enableDashboards = contextState['enableDashboards'] === true
     const enableOmitDestroy = contextState['enableOmitDestroy'] === true
+    const firstTimeUser = contextState['firstTimeUser'] === true
+    const advancedMode = contextState['advancedMode'] === true
 
-    return { enableDashboards, enableOmitDestroy }
+    return { enableDashboards, enableOmitDestroy, firstTimeUser, advancedMode }
 }
 
 export function useExecutionOptionsState() {
-    const { enableDashboards, enableOmitDestroy } = useExecutionOptionsStateValue()
+    const { enableDashboards, enableOmitDestroy, firstTimeUser, advancedMode } = useExecutionOptionsStateValue()
     const contextDispatch = useContextDispatch()
 
     const setProperty = (property, value) => {
@@ -130,6 +132,14 @@ export function useExecutionOptionsState() {
         setProperty("enableOmitDestroy", value)
     }
 
+    const setFirstTimeUser = (value) => {
+        setProperty("firstTimeUser", value)
+    }
 
-    return { enableDashboards, enableOmitDestroy, setEnableDashboards, setEnableOmitDestroy }
+    const setAdvancedMode = (value) => {
+        setProperty("advancedMode", value)
+    }
+
+
+    return { enableDashboards, enableOmitDestroy, firstTimeUser, advancedMode, setEnableDashboards, setEnableOmitDestroy, setFirstTimeUser, setAdvancedMode }
 }

--- a/react-frontend/src/context/TenantListContext.js
+++ b/react-frontend/src/context/TenantListContext.js
@@ -23,7 +23,7 @@ export const TenantListContextState = React.createContext();
 export const TenantListContextDispatch = React.createContext();
 
 function getDefaultTenant() {
-    const tenant = { label: "", headers: "", APIKey: "", url: "", clientID: "", accountID: "", clientSecret: "", monacoConcurrentRequests: 10, disableSSLVerification: false, disableSystemProxies: false, proxyURL: "", notes: "" }
+    const tenant = { label: "", headers: "", APIKey: "", url: "", connectionTested: undefined, clientID: "", accountID: "", clientSecret: "", monacoConcurrentRequests: 10, disableSSLVerification: false, disableSystemProxies: false, proxyURL: "", notes: "" }
     return { ...tenant }
 }
 
@@ -196,15 +196,27 @@ export function useTenant(key) {
             contextDispatch(action)
         }
 
+        const setConnectionTested = (value) => {
+            setTenantProperty("connectionTested", value)
+        }
+
         const setTenantLabel = (value) => {
             setTenantProperty("label", value)
         }
 
+        const needToTestConnection = () => {
+            if (tenant.connectionTested !== undefined) {
+                setConnectionTested(undefined)
+            }
+        }
+
         const setTenantUrl = (value) => {
+            needToTestConnection()
             setTenantProperty("url", value)
         }
 
         const setTenantHeaders = (value) => {
+            needToTestConnection()
             setTenantProperty("headers", value)
         }
 
@@ -221,6 +233,7 @@ export function useTenant(key) {
         }
 
         const setTenantAPIKey = (value) => {
+            needToTestConnection()
             setTenantProperty("APIKey", value)
         }
 
@@ -229,14 +242,17 @@ export function useTenant(key) {
         }
 
         const setTenantDisableSSLVerification = (value) => {
+            needToTestConnection()
             setTenantProperty("disableSSLVerification", value)
         }
 
         const setTenantDisableSystemProxies = (value) => {
+            needToTestConnection()
             setTenantProperty("disableSystemProxies", value)
         }
 
         const setTenantProxyURL = (value) => {
+            needToTestConnection()
             setTenantProperty("proxyURL", value)
         }
 
@@ -244,7 +260,7 @@ export function useTenant(key) {
             setTenantProperty("notes", value)
         }
 
-        return { tenant, setTenantLabel, setTenantUrl, setTenantHeaders, setTenantAPIKey, setTenantClientID, setTenantAccountID, setTenantClientSecret, setTenantMonacoConcurrentRequests, setTenantDisableSSLVerification, setTenantDisableSystemProxies, setTenantProxyURL, setTenantNotes }
+        return { tenant, setTenantLabel, setTenantUrl, setConnectionTested, setTenantHeaders, setTenantAPIKey, setTenantClientID, setTenantAccountID, setTenantClientSecret, setTenantMonacoConcurrentRequests, setTenantDisableSSLVerification, setTenantDisableSystemProxies, setTenantProxyURL, setTenantNotes }
     }
     return {}
 }

--- a/react-frontend/src/context/components/AppContext.js
+++ b/react-frontend/src/context/components/AppContext.js
@@ -18,7 +18,6 @@ import { ExecutionOptionsContextDispatch, ExecutionOptionsContextState, useExecu
 import { SettingContextDispatch, SettingContextState, useSettingContextReducer } from "../SettingContext";
 import { TenantListContextDispatch, TenantListContextState, useTenantListContextReducer } from "../TenantListContext";
 import { EntityFilterListContextDispatch, EntityFilterListContextState, useEntityFilterListContextReducer } from "../EntityFilterContext";
-import { ResultContextDispatch, ResultContextState, useResultContextReducer } from "../ResultContext";
 
 export default function AppContext(props) {
     const [tenantListState, tenantListDispatch] = useTenantListContextReducer()
@@ -26,7 +25,6 @@ export default function AppContext(props) {
     const [settingState, settingDispatch] = useSettingContextReducer()
     const [contextMenuState, contextMenuDispatch] = useContextMenuContextReducer()
     const [entityFilterListState, entityFilterListDispatch] = useEntityFilterListContextReducer()
-    const [resultState, resultDispatch] = useResultContextReducer()
     return (
         <TenantListContextState.Provider value={tenantListState}>
             <TenantListContextDispatch.Provider value={tenantListDispatch}>
@@ -38,11 +36,7 @@ export default function AppContext(props) {
                                     <ContextMenuContextDispatch.Provider value={contextMenuDispatch}>
                                         <EntityFilterListContextState.Provider value={entityFilterListState}>
                                             <EntityFilterListContextDispatch.Provider value={entityFilterListDispatch}>
-                                                <ResultContextState.Provider value={resultState}>
-                                                    <ResultContextDispatch.Provider value={resultDispatch}>
-                                                        {props.children}
-                                                    </ResultContextDispatch.Provider>
-                                                </ResultContextState.Provider>
+                                                {props.children}
                                             </EntityFilterListContextDispatch.Provider>
                                         </EntityFilterListContextState.Provider>
                                     </ContextMenuContextDispatch.Provider>

--- a/react-frontend/src/context/components/MigrateContext.js
+++ b/react-frontend/src/context/components/MigrateContext.js
@@ -14,16 +14,23 @@ limitations under the License.
 */
 
 import { HistoryContextDispatch, HistoryContextState, useHistoryContextReducer } from "../HistoryContext";
+import { ResultContextDispatch, ResultContextState, useResultContextReducer } from "../ResultContext";
 
 
 export default function MigrateContext(props) {
     const [historyState, historyDispatch] = useHistoryContextReducer()
+    const [resultState, resultDispatch] = useResultContextReducer()
 
     return (
         <HistoryContextState.Provider value={historyState}>
             <HistoryContextDispatch.Provider value={historyDispatch}>
-                {props.children}
+                <ResultContextState.Provider value={resultState}>
+                    <ResultContextDispatch.Provider value={resultDispatch}>
+                        {props.children}
+                    </ResultContextDispatch.Provider>
+                </ResultContextState.Provider>
             </HistoryContextDispatch.Provider>
         </HistoryContextState.Provider>
     )
 }
+

--- a/react-frontend/src/context/components/MigrateContextLoad.js
+++ b/react-frontend/src/context/components/MigrateContextLoad.js
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
+import React, { useCallback } from "react";
 import { useLoadHistory } from "../HistoryContext";
 
 export default function MigrateContextLoad(props) {
@@ -26,13 +26,13 @@ export default function MigrateContextLoad(props) {
         return false
     }, [isHistoryLoaded])
 
-    const genChildren = () => {
+    const genChildren = useCallback(() => {
         if (isLoaded) {
             return props.children
         } else {
             return null
         }
-    }
+    }, [isLoaded, props.children])
 
     return (
         <React.Fragment>

--- a/react-frontend/src/credentials/AddTenantButton.js
+++ b/react-frontend/src/credentials/AddTenantButton.js
@@ -19,10 +19,10 @@ import IconButton from '@mui/material/IconButton';
 import { Typography } from '@mui/material';
 import { TENANT_KEY_TYPE_MAIN, useTenantKey, useTenantList } from '../context/TenantListContext';
 
-export default function AddTenantButton({tenantType=TENANT_KEY_TYPE_MAIN}) {
+export default function AddTenantButton({tenantKeyType=TENANT_KEY_TYPE_MAIN}) {
 
     const { addTenant } = useTenantList()
-    const { setTenantKey } = useTenantKey(tenantType)
+    const { setTenantKey } = useTenantKey(tenantKeyType)
     
     const handleAddTenant = () => {
         const newTenantId = addTenant()

--- a/react-frontend/src/credentials/CopyTenantButton.js
+++ b/react-frontend/src/credentials/CopyTenantButton.js
@@ -19,10 +19,10 @@ import IconButton from '@mui/material/IconButton';
 import { Typography } from '@mui/material';
 import { TENANT_KEY_TYPE_MAIN, useTenant, useTenantKey, useTenantList } from '../context/TenantListContext';
 
-export default function CopyTenantButton({ tenantType = TENANT_KEY_TYPE_MAIN }) {
+export default function CopyTenantButton({ tenantKeyType = TENANT_KEY_TYPE_MAIN }) {
 
     const { addTenant } = useTenantList()
-    const { tenantKey, setTenantKey } = useTenantKey(tenantType)
+    const { tenantKey, setTenantKey } = useTenantKey(tenantKeyType)
     const { tenant } = useTenant(tenantKey)
 
     const handleCopyTenant = () => {

--- a/react-frontend/src/credentials/CredentialPanel.js
+++ b/react-frontend/src/credentials/CredentialPanel.js
@@ -33,9 +33,9 @@ export default function CredentialPanel() {
             gridComponentList.push(
                 <React.Fragment>
                     <Grid item xs={5}>
-                        <AddTenantButton tenantType={keyType} />
-                        <CopyTenantButton tenantType={keyType} />
-                        <TenantConfig tenantType={keyType} />
+                        <AddTenantButton tenantKeyType={keyType} />
+                        <CopyTenantButton tenantKeyType={keyType} />
+                        <TenantConfig tenantKeyType={keyType} />
                     </Grid>
                     <Grid item xs={1} />
                 </React.Fragment>

--- a/react-frontend/src/credentials/TenantConfig.js
+++ b/react-frontend/src/credentials/TenantConfig.js
@@ -16,36 +16,22 @@ limitations under the License.
 import { Fragment } from "react";
 import * as React from 'react';
 import FormControl from '@mui/material/FormControl';
-import IconButton from '@mui/material/IconButton';
-import ContentPasteIcon from '@mui/icons-material/ContentPaste';
-import ClearIcon from '@mui/icons-material/Clear';
-import { Box, Checkbox, FormControlLabel, TextField, Typography } from '@mui/material';
+import { Box, TextField, Typography } from '@mui/material';
 import { TENANT_KEY_TYPE_MAIN, useTenant, useTenantKey } from "../context/TenantListContext";
-import TestConnectionButton from "./TestConnectionButton";
-import { PROXY_GET_ENV, backendGet } from "../backend/backend";
+import TenantConfigBasics from "./TenantConfigBasics";
+import TenantConfigConnectionOptions from "./TenantConfigConnectionOptions";
 
 export const DEFAULT_MONACO_CONCURRENT_REQUESTS = 10
 
-export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
-    const [envProxyURL, setEnvProxyUrl] = React.useState("")
-    const [tenantUrlError, setTenantUrlError] = React.useState(false)
-    const [tenantUrlErrorMessage, setTenantUrlErrorMessage] = React.useState("")
-    const { tenantKey } = useTenantKey(tenantType)
+export default function TenantConfig({ tenantKeyType = TENANT_KEY_TYPE_MAIN }) {
+    const { tenantKey } = useTenantKey(tenantKeyType)
     const {
-        tenant, setTenantLabel, setTenantUrl, setTenantHeaders, setTenantAPIKey,
+        tenant, setTenantHeaders,
         setTenantClientID, setTenantAccountID, setTenantClientSecret,
-        setTenantMonacoConcurrentRequests, setTenantDisableSSLVerification,
-        setTenantDisableSystemProxies, setTenantProxyURL, setTenantNotes
+        setTenantMonacoConcurrentRequests,
+        setTenantNotes
     } = useTenant(tenantKey)
 
-
-    const tenantUrlDisplay = React.useMemo(() => {
-        if (!tenant.url || tenant.url === "") {
-            return "https://<YOUR_TENANT>.live.dynatrace.com/"
-        } else {
-            return tenant.url
-        }
-    }, [tenant.url])
 
     const tenantMonacoConcurrentRequests = React.useMemo(() => {
         if (!tenant.monacoConcurrentRequests || tenant.monacoConcurrentRequests === "" || tenant.monacoConcurrentRequests === 0) {
@@ -55,48 +41,6 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
         }
     }, [tenant.monacoConcurrentRequests])
 
-    React.useEffect(() => {
-        backendGet(PROXY_GET_ENV, null,
-            promise =>
-                promise
-                    .then(response => {
-                        return response.json()
-                    })
-                    .then(data => {
-                        setEnvProxyUrl(data["proxy"])
-                    })
-        )
-    }, [])
-
-    React.useEffect(() => {
-        let urlError = false;
-        let message = "";
-        console.log(tenant.url, typeof tenant.url)
-
-        if (tenant.url.endsWith("/")) {
-            // pass
-        } else {
-            urlError = true
-            message += "The URL should end with a slash '/'. "
-        }
-
-        if (tenant.url.includes(".live.dynatrace.com")) {
-            // pass
-        } else {
-            if (tenant.url.includes(".apps.dynatrace.com")) {
-                urlError = true
-                message += "Use the '.live' URL, not the '.apps' one. "
-            }
-        }
-
-        if (tenantUrlError !== urlError) {
-            setTenantUrlError(urlError)
-        }
-        if (tenantUrlErrorMessage !== message) {
-            setTenantUrlErrorMessage(message)
-        }
-
-    }, [tenant])
 
     /*
     const pasteHeaders = () => {
@@ -114,21 +58,6 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
         setTenantHeaders("")
     }
     */
-
-    const pasteAPIKey = () => {
-        navigator.clipboard.readText()
-            .then(text => {
-                setTenantAPIKey(text)
-            })
-            .catch(err => {
-                console.error('Failed to read clipboard contents: ', err);
-            });
-
-    }
-
-    const clearAPIKey = () => {
-        setTenantAPIKey("")
-    }
 
     const pasteClientID = () => {
         navigator.clipboard.readText()
@@ -171,39 +100,13 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
 
     }
 
-    const clearProxyURL = () => {
-        setTenantProxyURL("")
-    }
-
-    const pasteProxyURL = () => {
-        navigator.clipboard.readText()
-            .then(text => {
-                setTenantProxyURL(text)
-            })
-            .catch(err => {
-                console.error('Failed to read clipboard contents: ', err);
-            });
-
-    }
 
     const clearClientSecret = () => {
         setTenantClientSecret("")
     }
 
-    const handleChangeLabel = (event) => {
-        setTenantLabel(event.target.value)
-    }
-
-    const handleChangeUrl = (event) => {
-        setTenantUrl(event.target.value)
-    }
-
     const handleChangeHeaders = (event) => {
         setTenantHeaders(event.target.value)
-    }
-
-    const handleChangeAPIKey = (event) => {
-        setTenantAPIKey(event.target.value)
     }
 
     const handleChangeClientID = (event) => {
@@ -222,87 +125,14 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
         setTenantMonacoConcurrentRequests(event.target.value)
     }
 
-    const handleChangeDisableSSLVerification = (event) => {
-        setTenantDisableSSLVerification(event.target.checked)
-    }
-
-    const handleChangeDisableSystemProxies = (event) => {
-        setTenantDisableSystemProxies(event.target.checked)
-    }
-
-    const handleChangeProxyURL = (event) => {
-        setTenantProxyURL(event.target.value)
-    }
-
     const handleChangeNotes = (event) => {
         setTenantNotes(event.target.value)
     }
 
     return (
         <Fragment>
-            <Box sx={{ mt: 2 }}>
-                <Typography>Credentials [Required]:</Typography>
-                <Box sx={{ ml: 2 }}>
-                    <React.Fragment>
-                        <FormControl fullWidth>
-                            <TextField id={"tenant-text-field" + tenantKey} variant="standard"
-                                label="Tenant Label" value={tenant.label} onChange={handleChangeLabel} />
-                        </FormControl>
-                    </React.Fragment>
-                    <React.Fragment>
-                        <FormControl fullWidth>
-                            <TextField id={"tenant-url-field" + tenantKey} variant="standard"
-                                label="Tenant Url (https://<YOUR_TENANT>.live.dynatrace.com/)" value={tenantUrlDisplay}
-                                onChange={handleChangeUrl}
-                                error={tenantUrlError} helperText={tenantUrlErrorMessage} />
-                        </FormControl>
-                    </React.Fragment>
-                    <React.Fragment>
-                        <FormControl fullWidth>
-                            <TextField id={"api_key-text-field" + tenantKey} variant="standard" type="password"
-                                label="Access Token (API Key): see documentation tab" value={tenant.APIKey} onChange={handleChangeAPIKey} />
-                        </FormControl>
-                    </React.Fragment>
-                    <React.Fragment>
-                        <IconButton onClick={pasteAPIKey}>
-                            <ContentPasteIcon />
-                        </IconButton>
-                        <IconButton onClick={clearAPIKey}>
-                            <ClearIcon />
-                        </IconButton>
-                    </React.Fragment>
-                    <React.Fragment>
-                        <TestConnectionButton tenantKey={tenantKey} />
-                    </React.Fragment>
-                </Box>
-            </Box>
-            <Box sx={{ mt: 2 }}>
-                <Typography>Connection Options [Optional]:</Typography>
-                <Box sx={{ ml: 2 }}>
-                    <React.Fragment>
-                        <FormControl fullWidth>
-                            <FormControlLabel control={<Checkbox checked={tenant.disableSystemProxies === true}
-                                onChange={handleChangeDisableSystemProxies} />} label={"Disable Proxies (HTTP_PROXY & HTTPS_PROXY)"} />
-                        </FormControl>
-                    </React.Fragment>
-                </Box>
-                <Box sx={{ ml: 2 }}>
-                    <React.Fragment>
-                        <FormControl fullWidth>
-                            <TextField id={"proxyURL-text-field" + tenantKey} variant="standard"
-                                label={getProxyLabel(envProxyURL)} value={tenant.proxyURL} onChange={handleChangeProxyURL} disabled={tenant.disableSystemProxies} />
-                        </FormControl>
-                    </React.Fragment>
-                    <React.Fragment>
-                        <IconButton onClick={pasteProxyURL} disabled={tenant.disableSystemProxies}>
-                            <ContentPasteIcon />
-                        </IconButton>
-                        <IconButton onClick={clearProxyURL} disabled={tenant.disableSystemProxies}>
-                            <ClearIcon />
-                        </IconButton>
-                    </React.Fragment>
-                </Box>
-            </Box>
+            <TenantConfigBasics tenantKeyType={tenantKeyType} />
+            <TenantConfigConnectionOptions tenantKeyType={tenantKeyType} />
             <Box sx={{ mt: 2 }}>
                 <Typography>Other:</Typography>
                 <Box sx={{ ml: 2 }}>
@@ -328,17 +158,6 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
             </Box>
         </Fragment>
     );
-}
-
-const getProxyLabel = (envProxyURL) => {
-    let label = "Proxy URL"
-    if (envProxyURL && envProxyURL !== "") {
-        label += " [Default: "
-        label += envProxyURL
-        label += "]"
-    }
-
-    return label
 }
 
 /*

--- a/react-frontend/src/credentials/TenantConfigBasics.js
+++ b/react-frontend/src/credentials/TenantConfigBasics.js
@@ -1,0 +1,142 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import * as React from 'react';
+import FormControl from '@mui/material/FormControl';
+import IconButton from '@mui/material/IconButton';
+import ContentPasteIcon from '@mui/icons-material/ContentPaste';
+import ClearIcon from '@mui/icons-material/Clear';
+import { Box, TextField, Typography } from '@mui/material';
+import { TENANT_KEY_TYPE_MAIN, useTenant, useTenantKey } from "../context/TenantListContext";
+import TestConnectionButton from "./TestConnectionButton";
+import EfficientAccordion from '../result/EfficientAccordion';
+import DocumAPIToken from '../docum/DocumAPIToken';
+
+export default function TenantConfigBasics({ tenantKeyType = TENANT_KEY_TYPE_MAIN }) {
+    const [tenantUrlError, setTenantUrlError] = React.useState(false)
+    const [tenantUrlErrorMessage, setTenantUrlErrorMessage] = React.useState("")
+    const { tenantKey } = useTenantKey(tenantKeyType)
+    const { tenant, setTenantLabel, setTenantUrl, setTenantAPIKey } = useTenant(tenantKey)
+
+    const tenantUrlDisplay = React.useMemo(() => {
+        if (!tenant.url || tenant.url === "") {
+            return "https://<YOUR_TENANT>.live.dynatrace.com/"
+        } else {
+            return tenant.url
+        }
+    }, [tenant.url])
+
+    React.useEffect(() => {
+        let urlError = false;
+        let message = "";
+
+        if (tenant.url.endsWith("/")) {
+            // pass
+        } else {
+            urlError = true
+            message += "The URL should end with a slash '/'. "
+        }
+
+        if (tenant.url.includes(".live.dynatrace.com")) {
+            // pass
+        } else {
+            if (tenant.url.includes(".apps.dynatrace.com")) {
+                urlError = true
+                message += "Use the '.live' URL, not the '.apps' one. "
+            }
+        }
+
+        if (tenantUrlError !== urlError) {
+            setTenantUrlError(urlError)
+        }
+        if (tenantUrlErrorMessage !== message) {
+            setTenantUrlErrorMessage(message)
+        }
+
+    }, [tenant])
+
+    const pasteAPIKey = () => {
+        navigator.clipboard.readText()
+            .then(text => {
+                setTenantAPIKey(text)
+            })
+            .catch(err => {
+                console.error('Failed to read clipboard contents: ', err);
+            });
+
+    }
+
+    const clearAPIKey = () => {
+        setTenantAPIKey("")
+    }
+
+    const handleChangeLabel = (event) => {
+        setTenantLabel(event.target.value)
+    }
+
+    const handleChangeUrl = (event) => {
+        setTenantUrl(event.target.value)
+    }
+
+    const handleChangeAPIKey = (event) => {
+        setTenantAPIKey(event.target.value)
+    }
+
+    return (
+        <Box sx={{ mt: 2 }}>
+            <Typography>Credentials [Required]:</Typography>
+            <Box sx={{ ml: 2 }}>
+                <React.Fragment>
+                    <FormControl fullWidth>
+                        <TextField id={"tenant-text-field" + tenantKey} variant="standard"
+                            label="Tenant Label" value={tenant.label} onChange={handleChangeLabel} />
+                    </FormControl>
+                </React.Fragment>
+                <React.Fragment>
+                    <FormControl fullWidth>
+                        <TextField id={"tenant-url-field" + tenantKey} variant="standard"
+                            label="Tenant Url (https://<YOUR_TENANT>.live.dynatrace.com/)" value={tenantUrlDisplay}
+                            onChange={handleChangeUrl}
+                            error={tenantUrlError} helperText={tenantUrlErrorMessage} />
+                    </FormControl>
+                </React.Fragment>
+                <React.Fragment>
+                    <FormControl fullWidth>
+                        <TextField id={"api_key-text-field" + tenantKey} variant="standard" type="password"
+                            label="Access Token (API Key): see documentation tab" value={tenant.APIKey} onChange={handleChangeAPIKey} />
+                    </FormControl>
+                </React.Fragment>
+                <React.Fragment>
+                    <IconButton onClick={pasteAPIKey}>
+                        <ContentPasteIcon />
+                    </IconButton>
+                    <IconButton onClick={clearAPIKey}>
+                        <ClearIcon />
+                    </IconButton>
+                </React.Fragment>
+                <React.Fragment>
+                    <EfficientAccordion
+                        defaultExpanded={false}
+                        label="Access Token Documentation (and curl commands)"
+                        labelColor="primary.main"
+                        componentList={[(<DocumAPIToken url={tenant.url} tenantKeyType={tenantKeyType} />)]} />
+                </React.Fragment>
+                <React.Fragment>
+                    <TestConnectionButton tenantKey={tenantKey} />
+                </React.Fragment>
+            </Box>
+        </Box>
+    );
+}

--- a/react-frontend/src/credentials/TenantConfigConnectionOptions.js
+++ b/react-frontend/src/credentials/TenantConfigConnectionOptions.js
@@ -1,0 +1,117 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import { Fragment } from "react";
+import * as React from 'react';
+import FormControl from '@mui/material/FormControl';
+import IconButton from '@mui/material/IconButton';
+import ContentPasteIcon from '@mui/icons-material/ContentPaste';
+import ClearIcon from '@mui/icons-material/Clear';
+import { Box, Checkbox, FormControlLabel, TextField, Typography } from '@mui/material';
+import { TENANT_KEY_TYPE_MAIN, useTenant, useTenantKey } from "../context/TenantListContext";
+import { PROXY_GET_ENV, backendGet } from "../backend/backend";
+
+export default function TenantConfigConnectionOptions({ tenantKeyType = TENANT_KEY_TYPE_MAIN }) {
+    const [envProxyURL, setEnvProxyUrl] = React.useState("")
+    const { tenantKey } = useTenantKey(tenantKeyType)
+    const {
+        tenant, setTenantDisableSSLVerification,
+        setTenantDisableSystemProxies, setTenantProxyURL
+    } = useTenant(tenantKey)
+
+
+    React.useEffect(() => {
+        backendGet(PROXY_GET_ENV, null,
+            promise =>
+                promise
+                    .then(response => {
+                        return response.json()
+                    })
+                    .then(data => {
+                        setEnvProxyUrl(data["proxy"])
+                    })
+        )
+    }, [])
+
+    const clearProxyURL = () => {
+        setTenantProxyURL("")
+    }
+
+    const pasteProxyURL = () => {
+        navigator.clipboard.readText()
+            .then(text => {
+                setTenantProxyURL(text)
+            })
+            .catch(err => {
+                console.error('Failed to read clipboard contents: ', err);
+            });
+
+    }
+
+    const handleChangeDisableSSLVerification = (event) => {
+        setTenantDisableSSLVerification(event.target.checked)
+    }
+
+    const handleChangeDisableSystemProxies = (event) => {
+        setTenantDisableSystemProxies(event.target.checked)
+    }
+
+    const handleChangeProxyURL = (event) => {
+        setTenantProxyURL(event.target.value)
+    }
+
+    return (
+        <Fragment>
+            <Box sx={{ mt: 2 }}>
+                <Typography>Connection Options [Optional]:</Typography>
+                <Box sx={{ ml: 2 }}>
+                    <React.Fragment>
+                        <FormControl fullWidth>
+                            <FormControlLabel control={<Checkbox checked={tenant.disableSystemProxies === true}
+                                onChange={handleChangeDisableSystemProxies} />} label={"Disable Proxies (HTTP_PROXY & HTTPS_PROXY)"} />
+                        </FormControl>
+                    </React.Fragment>
+                </Box>
+                <Box sx={{ ml: 2 }}>
+                    <React.Fragment>
+                        <FormControl fullWidth>
+                            <TextField id={"proxyURL-text-field" + tenantKey} variant="standard"
+                                label={getProxyLabel(envProxyURL)} value={tenant.proxyURL} onChange={handleChangeProxyURL} disabled={tenant.disableSystemProxies} />
+                        </FormControl>
+                    </React.Fragment>
+                    <React.Fragment>
+                        <IconButton onClick={pasteProxyURL} disabled={tenant.disableSystemProxies}>
+                            <ContentPasteIcon />
+                        </IconButton>
+                        <IconButton onClick={clearProxyURL} disabled={tenant.disableSystemProxies}>
+                            <ClearIcon />
+                        </IconButton>
+                    </React.Fragment>
+                </Box>
+            </Box>
+        </Fragment>
+    );
+}
+
+const getProxyLabel = (envProxyURL) => {
+    let label = "Proxy URL"
+    if (envProxyURL && envProxyURL !== "") {
+        label += " [Default: "
+        label += envProxyURL
+        label += "]"
+    }
+
+    return label
+}

--- a/react-frontend/src/extraction/ExtractConfigs.js
+++ b/react-frontend/src/extraction/ExtractConfigs.js
@@ -18,13 +18,13 @@ import { EXTRACT_CONFIGS } from '../backend/backend';
 import { TENANT_KEY_TYPE_MAIN } from '../context/TenantListContext';
 import ExtractButton from './ExtractButton';
 
-export default function ExtractConfigs({ tenantType = TENANT_KEY_TYPE_MAIN }) {
+export default function ExtractConfigs({ tenantKeyType = TENANT_KEY_TYPE_MAIN }) {
 
     return (
         <React.Fragment>
-            <ExtractButton handleChange={() => { }} api={EXTRACT_CONFIGS}
+            <ExtractButton api={EXTRACT_CONFIGS}
                 label="Extract Configs (Monaco cli)"
-                tenantType={tenantType} />
+                tenantKeyType={tenantKeyType} />
         </React.Fragment>
     );
 }

--- a/react-frontend/src/extraction/ExtractEntities.js
+++ b/react-frontend/src/extraction/ExtractEntities.js
@@ -19,11 +19,12 @@ import ExtractButton from './ExtractButton';
 import { Box, TextField } from '@mui/material';
 import { FormControl } from '@mui/base';
 
-const timeFrom7WeeksMinutes = 7 * 7 * 24 * 60
+export const timeFrom7WeeksMinutes = 7 * 7 * 24 * 60
+export const timeToNow = 0
 
-export default function ExtractEntities({ tenantType }) {
+export default function ExtractEntities({ tenantKeyType }) {
     const [timeFromMinute, setTimeFromMinute] = React.useState(timeFrom7WeeksMinutes)
-    const [timeToMinute, setTimeToMinute] = React.useState(0)
+    const [timeToMinute, setTimeToMinute] = React.useState(timeToNow)
 
     const handleTimeFromMinute = (event) => {
         setTimeFromMinute(event.target.value)
@@ -34,9 +35,9 @@ export default function ExtractEntities({ tenantType }) {
 
     return (
         <React.Fragment>
-            <ExtractButton handleChange={() => { }} api={EXTRACT_ENTITY_V2}
+            <ExtractButton api={EXTRACT_ENTITY_V2}
                 label="Extract Entities (Monaco cli)"
-                tenantType={tenantType}
+                tenantKeyType={tenantKeyType}
                 extraSearchParams={{ 'time_from_minutes': timeFromMinute, 'time_to_minutes': timeToMinute }} />
             <Box sx={{ ml: 2 }}>
                 <React.Fragment>

--- a/react-frontend/src/extraction/ExtractionHooks.js
+++ b/react-frontend/src/extraction/ExtractionHooks.js
@@ -1,0 +1,55 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import * as React from 'react';
+import { EXTRACT_CONFIGS, EXTRACT_ENTITY_V2, backendPost } from "../backend/backend";
+import { timeFrom7WeeksMinutes, timeToNow } from './ExtractEntities';
+import { DONE, ERROR, LOADING, useProgress } from '../progress/ProgressHook';
+
+export function useHandleExtractConfigs(tenantKey) {
+    const { progress, setProgress, progressComponent } = useProgress()
+
+    const handleExtractConfigs = useHandleExtract(tenantKey, {}, setProgress, EXTRACT_CONFIGS)
+
+    return { progress, progressComponent, handleExtractConfigs }
+}
+
+export function useHandleExtractEntities(tenantKey, timeFrom = timeFrom7WeeksMinutes, timeTo = timeToNow) {
+    const { progress, setProgress, progressComponent } = useProgress()
+
+    const handleExtractEntities = useHandleExtract(tenantKey, { 'time_from_minutes': timeFrom, 'time_to_minutes': timeTo }, setProgress, EXTRACT_ENTITY_V2)
+
+    return { progress, progressComponent, handleExtractEntities }
+}
+
+export function useHandleExtract(tenantKey, extraSearchParams, setProgress, api) {
+    return React.useCallback(() => {
+        const searchParams = { 'tenant_key': tenantKey, 'use_cache': false, ...extraSearchParams };
+
+        setProgress(LOADING);
+        const thenFunction = promise => promise
+            .then(response => {
+                setProgress(DONE);
+                return response.json();
+            })
+
+        const catchFunction = (error) => {
+            setProgress(ERROR)
+        }
+
+        backendPost(api, null, searchParams, thenFunction, catchFunction);
+    }, [tenantKey, api, setProgress, extraSearchParams]);
+}
+

--- a/react-frontend/src/extraction/ExtractionSection.js
+++ b/react-frontend/src/extraction/ExtractionSection.js
@@ -21,18 +21,12 @@ import ExtractEntities from './ExtractEntities';
 import MonacoRequestsInfo from './MonacoRequestsInfo';
 import MigrateButtonControlled from '../migrate/MigrateButtonControlled';
 import ExecutionOptions from '../options/ExecutionOptions';
-import { useHistoryState } from '../context/HistoryContext'
-import { getTimestampActionId } from '../date/DateFormatter';
+import { usePostProcessEntityFilter } from '../migrate/PostProcessHooks';
 
 export default function ExtractionSection() {
     const gridConfigList = useMigrationGridConfig()
-    const { setLastPlanAllActionId } = useHistoryState()
 
-    const getActionId = React.useCallback(() => {
-        const newActionId = getTimestampActionId()
-        setLastPlanAllActionId(newActionId)
-        return newActionId
-    }, [setLastPlanAllActionId])
+    const entityFilter = usePostProcessEntityFilter()
 
     const extractionGridComponentList = React.useMemo(() => {
 
@@ -43,9 +37,9 @@ export default function ExtractionSection() {
             gridComponentList.push(
                 <React.Fragment>
                     <Grid item xs={5} id={keyType}>
-                        <ExtractConfigs tenantType={keyType} />
-                        <ExtractEntities tenantType={keyType} />
-                        <MonacoRequestsInfo tenantType={keyType} />
+                        <ExtractConfigs tenantKeyType={keyType} />
+                        <ExtractEntities tenantKeyType={keyType} />
+                        <MonacoRequestsInfo tenantKeyType={keyType} />
                     </Grid>
                     <Grid item xs={1} />
                 </React.Fragment>
@@ -59,7 +53,7 @@ export default function ExtractionSection() {
             <Paper sx={{ mt: 5, p: 1 }} elevation={3} >
                 <ExecutionOptions />
                 <MigrateButtonControlled handleChange={() => { }}
-                    entityFilter={{ 'applyMigrationChecked': true, getActionIdFunc: getActionId }}
+                    entityFilter={entityFilter}
                     label={"Post-Process extracted files, do this when extractions are completed (Terraform cli)"}
                     confirm={true} descLabel={""} />
             </Paper>

--- a/react-frontend/src/extraction/HorizontalStackedBar.js
+++ b/react-frontend/src/extraction/HorizontalStackedBar.js
@@ -17,7 +17,7 @@ import * as React from 'react';
 import HSBar from "react-horizontal-stacked-bar-chart";
 
 export const defaultColumnArray = ['data', '0']
-export const STATUS_ORDER = ["I", "A", "U", "D", "Other"]
+export const STATUS_ORDER = ["I", "A", "D", "U", "E"/*, "R"*/]
 
 export const STATUS_PREFIX = {
     "I": "",
@@ -26,7 +26,7 @@ export const STATUS_PREFIX = {
     "D": "-",
     "R": "",
     "E": "!",
-    "Other": "!",
+    "Other": "",
 }
 
 const ERROR_RED = "#BB0000"
@@ -38,7 +38,7 @@ export const STATUS_LABELS = {
     "D": "- Destroy",
     "R": "Refresh state",
     "E": "! Error",
-    "Other": "! Other",
+    "Other": "Other",
 }
 
 export const STATUS_COLORS = {
@@ -57,7 +57,7 @@ const statusColorsPale = {
     "A": "Honeydew",
     "D": "MistyRose",
     "R": "WhiteSmoke",
-    "E": ERROR_RED,
+    "E": "MistyRose",
     "Other": "WhiteSmoke",
 }
 

--- a/react-frontend/src/extraction/MonacoRequestsInfo.js
+++ b/react-frontend/src/extraction/MonacoRequestsInfo.js
@@ -19,9 +19,9 @@ import { TENANT_KEY_TYPE_MAIN, useTenant, useTenantKey } from '../context/Tenant
 import { DEFAULT_MONACO_CONCURRENT_REQUESTS } from '../credentials/TenantConfig';
 
 
-export default function MonacoRequestsInfo({ tenantType = TENANT_KEY_TYPE_MAIN }) {
+export default function MonacoRequestsInfo({ tenantKeyType = TENANT_KEY_TYPE_MAIN }) {
 
-    const { tenantKey } = useTenantKey(tenantType)
+    const { tenantKey } = useTenantKey(tenantKeyType)
     const { tenant } = useTenant(tenantKey)
 
     return (

--- a/react-frontend/src/match/MatchButton.js
+++ b/react-frontend/src/match/MatchButton.js
@@ -18,12 +18,12 @@ import IconButton from '@mui/material/IconButton';
 import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 import { Box, Typography } from '@mui/material';
 import { useHandlePostCurrent } from '../backend/useHandlePost';
-import { useProgress } from '../progress/ProgressHook';
+import { ERROR, useProgress } from '../progress/ProgressHook';
 
 export default function MatchButton({ handleChange, api, label, confirm = false }) {
 
-    const { setLoading, progressComponent } = useProgress()
-    const { handlePost } = useHandlePostCurrent(handleChange, api, setLoading)
+    const { progress, setProgress, progressComponent } = useProgress()
+    const { handlePost } = useHandlePostCurrent(handleChange, api, setProgress)
 
     const button = React.useMemo(() => {
 
@@ -36,13 +36,18 @@ export default function MatchButton({ handleChange, api, label, confirm = false 
             buttonIcon = (<PlayCircleOutlineIcon {...props} />)
         }
 
+        let buttonColor = "primary"
+        if (progress === ERROR) {
+            buttonColor = "error"
+        }
+
         return (
-            <IconButton onClick={handlePost} color='primary'>
+            <IconButton onClick={handlePost} color={buttonColor}>
                 {buttonIcon}
                 <Typography sx={{ ml: 1 }}>{label}</Typography>
             </IconButton>
         )
-    }, [label, handlePost, progressComponent])
+    }, [label, handlePost, progressComponent, progress])
 
     return (
         <Box sx={{ my: 1 }}>

--- a/react-frontend/src/migrate/ApplyAllHooks.js
+++ b/react-frontend/src/migrate/ApplyAllHooks.js
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import * as React from 'react';
+import { TERRAFORM_APPLY_ALL } from "../backend/backend";
+import { useProgress } from '../progress/ProgressHook';
+import { useHandlePostTerraform } from '../backend/useHandlePost';
+import { useHistoryStateValue } from '../context/HistoryContext';
+import { terraformParamsAll } from '../result/ResultDrawerDetailsAll';
+
+export function useHandleApplyAll() {
+    const { progress, setProgress, progressComponent } = useProgress()
+    const [applyStats, setApplyStats] = React.useState(null)
+
+    const handleChange = React.useCallback((data) => {
+        if (data && "ui_payload" in data && data["ui_payload"] && "stats" in data["ui_payload"] && data["ui_payload"]["stats"]) {
+            setApplyStats(data["ui_payload"]["stats"])
+        }
+    }, [setApplyStats])
+
+    const handleApplyAll = useApplyAllHandlePost(handleChange, setProgress)
+
+    return { progress, progressComponent, handleApplyAll, applyStats }
+}
+
+function useApplyAllHandlePost(handleChange, setProgress) {
+    const { lastPlanAllActionId } = useHistoryStateValue()
+    const handlePost = useHandlePostTerraform(terraformParamsAll, handleChange, TERRAFORM_APPLY_ALL, () => lastPlanAllActionId, setProgress)
+
+    return handlePost
+}

--- a/react-frontend/src/migrate/MigrateButton.js
+++ b/react-frontend/src/migrate/MigrateButton.js
@@ -22,10 +22,11 @@ import BackupIcon from '@mui/icons-material/Backup';
 import { genTenantLabel } from '../credentials/TenantSelector';
 import ConfirmAction from '../action/ConfirmAction';
 import { useConfirmAction } from './ConfirmHook';
+import { ERROR } from '../progress/ProgressHook';
 
 export default function MigrateButton({ label, handlePost, confirm = false, disabled = false,
-    progressComponent = null, runOnce = false,
-    descLabel = "Will send API Requests, updating your tenant's configuration." }) {
+    progressComponent = null, runOnce = false, progress = "",
+    descLabel = "Will send API Requests, updating your tenant's configuration.", }) {
 
     const { tenantKey: tenantKeyMain } = useTenantKey(TENANT_KEY_TYPE_TARGET)
     const { tenantKey: tenantKeyTarget } = useTenantKey(TENANT_KEY_TYPE_TARGET)
@@ -64,6 +65,10 @@ export default function MigrateButton({ label, handlePost, confirm = false, disa
             color = 'primary'
         }
 
+        if (progress === ERROR) {
+            color = 'error'
+        }
+
         if (progressComponent) {
             buttonIcon = progressComponent
         }
@@ -74,7 +79,7 @@ export default function MigrateButton({ label, handlePost, confirm = false, disa
                 <Typography sx={{ ml: 1 }}>{label}</Typography>
             </IconButton>
         )
-    }, [confirm, label, handleClickAction, disabled, progressComponent])
+    }, [confirm, label, handleClickAction, disabled, progressComponent, progress])
 
     const confirmDialog = React.useMemo(() => {
 

--- a/react-frontend/src/migrate/MigrateButtonControlled.js
+++ b/react-frontend/src/migrate/MigrateButtonControlled.js
@@ -22,12 +22,12 @@ import { useProgress } from '../progress/ProgressHook';
 export default function MigrateButtonControlled({ entityFilter, handleChange, label, confirm, disabled = false, descLabel = undefined }) {
 
 
-    const { setLoading, progressComponent } = useProgress()
+    const { progress, setProgress, progressComponent } = useProgress()
 
-    const handlePost = useHandlePostSpecific(entityFilter, handleChange, MIGRATE_SETTINGS_2_0, setLoading)
+    const handlePost = useHandlePostSpecific(entityFilter, handleChange, MIGRATE_SETTINGS_2_0, setProgress)
 
     return (
         <MigrateButton label={label} handlePost={handlePost} confirm={confirm}
-            disabled={disabled} progressComponent={progressComponent} descLabel={descLabel} />
+            disabled={disabled} progressComponent={progressComponent} progress={progress} descLabel={descLabel} />
     );
 }

--- a/react-frontend/src/migrate/MigrateTenant.js
+++ b/react-frontend/src/migrate/MigrateTenant.js
@@ -16,34 +16,34 @@ limitations under the License.
 import * as React from 'react';
 import { useMigrationResultHook } from '../result/ResultHook';
 import MigrateButtonUncontrolled from './MigrateButtonUncontrolled';
-import { useProgress } from '../progress/ProgressHook';
+import { DONE, ERROR, LOADING, useProgress } from '../progress/ProgressHook';
 import { TERRAFORM_LOAD_UI_PAYLOAD } from '../backend/backend';
 
 export default function MigrateTenant() {
 
-    const { setLoading, progressComponent } = useProgress()
+    const { progress, setProgress, progressComponent } = useProgress()
     const { setExtractedData, resultComponents } = useMigrationResultHook()
 
     const handleChange = React.useCallback((data) => {
         if (data === null) {
-            setLoading(true)
+            setProgress(LOADING)
             return
         }
 
-        setLoading(false)
-
         const { ui_payload } = data
         if (ui_payload) {
+            setProgress(DONE)
             setExtractedData(ui_payload)
         } else {
+            setProgress(ERROR)
             setExtractedData(null)
         }
 
-    }, [setExtractedData, setLoading])
+    }, [setExtractedData, setProgress])
 
     return (
         <React.Fragment>
-            <MigrateButtonUncontrolled handleChange={handleChange} label={"Reload"} confirm={false} progressComponent={progressComponent} runOnce={true} api={TERRAFORM_LOAD_UI_PAYLOAD} />
+            <MigrateButtonUncontrolled handleChange={handleChange} label={"Reload"} confirm={false} progressComponent={progressComponent} progress={progress} runOnce={true} api={TERRAFORM_LOAD_UI_PAYLOAD} />
             {resultComponents}
         </React.Fragment>
     );

--- a/react-frontend/src/migrate/PostProcessHooks.js
+++ b/react-frontend/src/migrate/PostProcessHooks.js
@@ -1,0 +1,55 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import * as React from 'react';
+import { MIGRATE_SETTINGS_2_0 } from "../backend/backend";
+import { useProgress } from '../progress/ProgressHook';
+import { useHandlePostSpecific } from '../backend/useHandlePost';
+import { getTimestampActionId } from '../date/DateFormatter';
+import { useHistoryState } from '../context/HistoryContext';
+
+export function useHandlePostProcess() {
+    const { progress, setProgress, progressComponent } = useProgress()
+    const [planStats, setPlanStats] = React.useState(null)
+
+    const handleChange = React.useCallback((data) => {
+        if(data && "stats" in data && data["stats"]) {
+            setPlanStats(data["stats"])
+        }
+    }, [setPlanStats])
+
+    const handlePostProcess = usePostProcessHandlePost(handleChange, setProgress)
+
+    return { progress, progressComponent, handlePostProcess, planStats }
+}
+
+function usePostProcessHandlePost(handleChange, setProgress) {
+    const entityFilter = usePostProcessEntityFilter()
+    const handlePost = useHandlePostSpecific(entityFilter, handleChange, MIGRATE_SETTINGS_2_0, setProgress)
+
+    return handlePost
+}
+
+export function usePostProcessEntityFilter() {
+    const { setLastPlanAllActionId } = useHistoryState()
+
+    const getActionId = React.useCallback(() => {
+        const newActionId = getTimestampActionId();
+        setLastPlanAllActionId(newActionId);
+        return newActionId;
+    }, [setLastPlanAllActionId]);
+
+    return { 'applyMigrationChecked': true, getActionIdFunc: getActionId }
+}

--- a/react-frontend/src/navigation/MainPage.js
+++ b/react-frontend/src/navigation/MainPage.js
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import * as React from 'react';
+import { useExecutionOptionsState } from '../context/ExecutionContext';
+import { UserPage } from './UserPage';
+import { FirstTimeUser } from '../options/FirstTimeUser';
+import { useTenant } from '../context/TenantListContext';
+
+export function MainPage(props) {
+  const { firstTimeUser, setFirstTimeUser } = useExecutionOptionsState()
+  const { tenant: { url, APIKey, label } } = useTenant("0")
+
+  const isFirstTimeUser = React.useMemo(() => {
+    const environment = process.env.REACT_APP_ENVIRONMENT;
+
+    if (firstTimeUser) {
+      if (environment === "test" || (url === "" && APIKey === "" && label === "")) {
+        return firstTimeUser
+      } else {
+        if (firstTimeUser !== false) {
+          setFirstTimeUser(false)
+        }
+        return false
+      }
+    }
+    return firstTimeUser
+
+  }, [url, APIKey, label, firstTimeUser, setFirstTimeUser])
+
+  return (
+    <React.Fragment>
+      {isFirstTimeUser ? <FirstTimeUser /> : <UserPage />}
+    </React.Fragment>
+  );
+}

--- a/react-frontend/src/navigation/TabPanelAssisted.js
+++ b/react-frontend/src/navigation/TabPanelAssisted.js
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import * as React from 'react';
+import TabPanelBar, { genTabConfig } from './TabPanelBar';
+import { WizExplained } from '../wizard/WizExplained';
+import { WizTenantConfig } from '../wizard/WizTenantConfig';
+import { TENANT_KEY_TYPE_MAIN, TENANT_KEY_TYPE_TARGET } from '../context/TenantListContext';
+import { WizRunPage } from '../wizard/WizRunPage';
+
+
+
+export default function TabPanelAssisted({ tabIdx, setTabIdx }) {
+
+  const genShowNextTab = React.useCallback((currentIdx) => {
+    return () => {
+      setTabIdx(currentIdx + 1)
+    }
+  }, [setTabIdx])
+
+  const tabConfig = React.useMemo(() => {
+    const tabConfigList = []
+
+    tabConfigList.push(
+      genTabConfig("Mode", <WizExplained key="WizExplained" showNextTab={genShowNextTab(tabConfigList.length)} />))
+    tabConfigList.push(
+      genTabConfig("Source", <WizTenantConfig key="WizTenantConfigMain" showNextTab={genShowNextTab(tabConfigList.length)}
+        tenantKeyType={TENANT_KEY_TYPE_MAIN} />))
+    tabConfigList.push(
+      genTabConfig("Target", <WizTenantConfig key="WizTenantConfigSource" showNextTab={genShowNextTab(tabConfigList.length)}
+        tenantKeyType={TENANT_KEY_TYPE_TARGET} />))
+    tabConfigList.push(
+      genTabConfig("Run", <WizRunPage key="WizRunPage" showNextTab={genShowNextTab(tabConfigList.length)} />))
+
+    return tabConfigList
+  }, [genShowNextTab])
+
+  return (
+    <TabPanelBar tabConfig={tabConfig} tabIdx={tabIdx} setTabIdx={setTabIdx} autoDisable />
+  )
+}

--- a/react-frontend/src/navigation/TabPanelBar.js
+++ b/react-frontend/src/navigation/TabPanelBar.js
@@ -25,12 +25,20 @@ export const genTabConfig = (tabLabel, tabComponent) => {
   return { tabLabel, tabComponent }
 }
 
-export default function TabPanelBar({tabConfig}) {
-  const [value, setValue] = React.useState(0);
+export default function TabPanelBar({ tabConfig, tabIdx: tabIdxReq, setTabIdx, autoDisable = false }) {
 
-  const handleChange = (event, newValue) => {
-    setValue(newValue);
-  };
+  const tabIdx = React.useMemo(() => {
+    if (tabIdxReq >= tabConfig.length) {
+      return tabConfig.length - 1
+    } else if (tabIdxReq < 0) {
+      return 0
+    }
+    return tabIdxReq
+  }, [tabIdxReq, tabConfig])
+
+  const handleChange = React.useCallback((event, newValue) => {
+    setTabIdx(newValue)
+  }, [setTabIdx])
 
   const [tabs, tabPanels] = React.useMemo(() => {
     const outTabs = []
@@ -40,11 +48,11 @@ export default function TabPanelBar({tabConfig}) {
       const { tabLabel, tabComponent } = tabConfig
       outTabs.push(
         (
-          <Tab label={tabLabel} key={"tab-" + index} id={`tab-${index}`} />
+          <Tab label={tabLabel} key={"tab-" + index} id={`tab-${index}`} disabled={index > tabIdx && autoDisable} />
         ))
       outTabPanels.push(
         (
-          <TabPanel value={value} index={index} key={"tab-panel-" + index}>
+          <TabPanel value={tabIdx} index={index} key={"tab-panel-" + index}>
             {tabComponent}
             <Box sx={{ my: drawerBleeding }} />
           </TabPanel>
@@ -53,12 +61,12 @@ export default function TabPanelBar({tabConfig}) {
     })
 
     return [outTabs, outTabPanels]
-  }, [value, tabConfig])
+  }, [tabIdx, tabConfig, autoDisable])
 
   return (
     <Box sx={{ width: '100%' }}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+        <Tabs value={tabIdx} onChange={handleChange} aria-label="basic tabs example">
           {tabs}
         </Tabs>
       </Box>

--- a/react-frontend/src/navigation/TabPanelMain.js
+++ b/react-frontend/src/navigation/TabPanelMain.js
@@ -22,9 +22,10 @@ import Setting from '../setting/Setting';
 import MigratePanel from '../migrate/MigratePanel';
 import TabPanelBar, { genTabConfig } from './TabPanelBar';
 import HistoryPanel from '../history/HistoryPanel';
+import { FirstTimeUser } from '../options/FirstTimeUser';
 
 
-const tabConfig = [
+const tabConfigMain = [
   genTabConfig("Credentials", <CredentialPanel />),
   genTabConfig("Extract", <ExtractionPanel />),
   //genTabConfig("Match", <MatchPanel />),
@@ -35,7 +36,22 @@ const tabConfig = [
 ]
 
 export default function TabPanelMain() {
+  const [tabIdx, setTabIdx] = React.useState(1);
+  const genShowNextTab = React.useCallback((currentIdx) => {
+    return () => {
+      setTabIdx(currentIdx + 1)
+    }
+  }, [setTabIdx])
+  const tabConfig = React.useMemo(() => {
+    const tabConfigList = []
+
+    tabConfigList.push(genTabConfig("Mode", <FirstTimeUser autoShowed={false} showNextTab={genShowNextTab(tabConfigList.length)} />))
+    tabConfigList.push(...tabConfigMain)
+
+    return tabConfigList
+  }, [genShowNextTab])
+
   return (
-    <TabPanelBar tabConfig={tabConfig} />
+    <TabPanelBar tabConfig={tabConfig} tabIdx={tabIdx} setTabIdx={setTabIdx} />
   )
 }

--- a/react-frontend/src/navigation/UserPage.js
+++ b/react-frontend/src/navigation/UserPage.js
@@ -14,19 +14,16 @@ limitations under the License.
 */
 
 import * as React from 'react';
-import DocumAPIToken from './DocumAPIToken';
-import TabPanelBar, { genTabConfig } from '../navigation/TabPanelBar';
+import { useExecutionOptionsStateValue } from '../context/ExecutionContext';
+import { WizardPage } from '../wizard/WizardPage';
+import TabPanelMain from './TabPanelMain';
 
+export function UserPage(props) {
+  const { advancedMode } = useExecutionOptionsStateValue()
 
-const tabConfig = [
-    genTabConfig("Access Tokens", <DocumAPIToken />),
-]
-
-export default function DocumPanel() {
-    const [tabIdx, setTabIdx] = React.useState(0);
-
-    return (
-        <TabPanelBar tabConfig={tabConfig} tabIdx={tabIdx} setTabIdx={setTabIdx} />
-    )
+  return (
+    <React.Fragment>
+      {advancedMode ? <TabPanelMain /> : <WizardPage />}
+    </React.Fragment>
+  );
 }
-

--- a/react-frontend/src/options/FirstTimeUser.js
+++ b/react-frontend/src/options/FirstTimeUser.js
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import * as React from 'react';
+import { useExecutionOptionsState } from '../context/ExecutionContext';
+import { Box, Button, Grid, Typography } from '@mui/material';
+
+export function FirstTimeUser({ autoShowed = true, showNextTab = () => { } }) {
+  const { firstTimeUser, setFirstTimeUser, setAdvancedMode } = useExecutionOptionsState()
+
+  const handleChangeAdvancedMode = React.useCallback((advancedMode) => {
+    if (firstTimeUser !== false) {
+      setFirstTimeUser(false)
+    }
+    setAdvancedMode(advancedMode)
+  }, [firstTimeUser, setFirstTimeUser, setAdvancedMode])
+
+  const [advancedLabel, advancedFunction] = React.useMemo(() => {
+    if (autoShowed === true) {
+      return ["Advanced", () => { handleChangeAdvancedMode(true) }]
+    } else {
+      return ["Continue", () => { showNextTab() }]
+    }
+
+  }, [autoShowed, handleChangeAdvancedMode, showNextTab])
+
+  return (
+    <React.Fragment>
+      <Box sx={{ ml: 4, }}>
+        {autoShowed ?
+          <Box sx={{ mt: 4 }}>
+            <Typography variant='h3'>
+              Welcome to the Dynatrace Config Manager
+            </Typography>
+
+            <Box sx={{ mt: 4, mb: 4 }} />
+            <Typography align="left">
+              It seems to be your first time using the tool.
+              <br />
+            </Typography>
+          </Box>
+          : null
+        }
+
+        <Typography align="left">
+          <br /> Two modes are available:
+        </Typography>
+        <Typography sx={{ ml: 2 }} align="left">
+          - <b>Assisted</b>: the execution is streamlined.
+          <br /> - <b>Advanced</b>: you get more control, at the cost of complexity.
+        </Typography>
+
+
+        <Grid item xs={3}></Grid>
+        <Box />
+        <Box sx={{ mt: 2, mb: 2 }} />
+        <Button sx={{ mx: 2 }} {...genMatrixButtonProps(MatrixBlue)} onClick={() => { handleChangeAdvancedMode(false) }}>Assisted</Button>
+        <Button sx={{ mx: 2 }} {...genMatrixButtonProps(MatrixRed)} onClick={advancedFunction}>{advancedLabel}</Button>
+
+      </Box>
+    </React.Fragment >
+  );
+}
+
+export const MatrixBlue = "#00FFFF"
+export const MatrixRed = "#FF0000"
+export const MatrixDisabled = "WhiteSmoke"
+
+export function genMatrixButtonProps(backgroundColor) {
+
+  let textColor = "black"
+  if (backgroundColor === MatrixRed || backgroundColor === "white") {
+    textColor = "white"
+  }
+
+  const style = {
+    borderRadius: 50,
+    padding: '10px 60px',
+    backgroundColor: backgroundColor,
+    color: textColor,
+  };
+
+  return {
+    variant: "contained",
+    style: style
+  }
+}

--- a/react-frontend/src/progress/ProgressHook.js
+++ b/react-frontend/src/progress/ProgressHook.js
@@ -17,19 +17,24 @@ import * as React from 'react'
 import _ from 'lodash';
 import { Box, CircularProgress } from '@mui/material';
 
+export const NOT_STARTED = "NOT STARTED"
+export const LOADING = "LOADING"
+export const ERROR = "ERROR"
+export const DONE = "DONE"
+
 export const useProgress = () => {
 
-    const { loading, setLoading } = useProgressState()
-    const progressComponent = useProgressIcon(loading)
+    const { progress, setProgress } = useProgressState()
+    const progressComponent = useProgressIcon(progress === LOADING)
 
-    return { setLoading, progressComponent }
+    return { progress, setProgress, progressComponent }
 }
 
 export const useProgressState = () => {
 
-    const [loading, setLoading] = React.useState(false)
+    const [progress, setProgress] = React.useState(NOT_STARTED)
 
-    return { loading, setLoading }
+    return { progress, setProgress }
 }
 
 export const useProgressIcon = (loading) => {
@@ -38,8 +43,8 @@ export const useProgressIcon = (loading) => {
         if (loading) {
             return (
 
-                <Box sx={{ my: 2 }}>
-                    <CircularProgress size={30} />
+                <Box sx={{ ml: 0.25, mr: 0.75 }}>
+                    <CircularProgress size={27} />
                 </Box>
             )
         }

--- a/react-frontend/src/result/ResultDrawerDetailsAll.js
+++ b/react-frontend/src/result/ResultDrawerDetailsAll.js
@@ -19,7 +19,7 @@ import { TERRAFORM_APPLY_ALL, TERRAFORM_PLAN_ALL } from '../backend/backend';
 import { useHistoryState } from '../context/HistoryContext';
 
 export const ALL = 'All'
-const terraformParams = [
+export const terraformParamsAll = [
     { 'module': ALL, 'module_trimmed': ALL, 'unique_name': ALL }
 ]
 
@@ -33,7 +33,7 @@ export default function ResultDrawerDetailsAll({ genTerraformActionComponent }) 
     const { lastPlanAllActionId, setLastPlanAllActionId } = useHistoryState()
 
     const terraformComponent = useMemo(() => {
-        return genTerraformActionComponent(lastPlanAllActionId, setLastPlanAllActionId, nbUpdate, terraformParams, module, resource, nbUpdateError, TERRAFORM_PLAN_ALL, TERRAFORM_APPLY_ALL)
+        return genTerraformActionComponent(lastPlanAllActionId, setLastPlanAllActionId, nbUpdate, terraformParamsAll, module, resource, nbUpdateError, TERRAFORM_PLAN_ALL, TERRAFORM_APPLY_ALL)
     }, [genTerraformActionComponent, lastPlanAllActionId, setLastPlanAllActionId])
 
     return (

--- a/react-frontend/src/result/ResultItemMenuHook.js
+++ b/react-frontend/src/result/ResultItemMenuHook.js
@@ -129,8 +129,8 @@ export function useResultItemMenu(setOpenDrawer, data) {
 
 }
 
-export function useTenantItems(contextNode, handleClose, tenantTypeKey = TENANT_KEY_TYPE_MAIN) {
-  const { tenantKey } = useTenantKey(tenantTypeKey)
+export function useTenantItems(contextNode, handleClose, tenantKeyType = TENANT_KEY_TYPE_MAIN) {
+  const { tenantKey } = useTenantKey(tenantKeyType)
 
   const tenantItems = React.useMemo(() => {
     let items = []
@@ -153,12 +153,12 @@ export function useTenantItems(contextNode, handleClose, tenantTypeKey = TENANT_
         entityId = keyObject['scope']
       }
 
-      if (tenantTypeKey === TENANT_KEY_TYPE_MAIN
+      if (tenantKeyType === TENANT_KEY_TYPE_MAIN
         && 'from' in keyObject) {
         entityId = keyObject['from']
       }
 
-      if (tenantTypeKey === TENANT_KEY_TYPE_TARGET
+      if (tenantKeyType === TENANT_KEY_TYPE_TARGET
         && 'to' in keyObject) {
         entityId = keyObject['to']
       }

--- a/react-frontend/src/result/StatsBar.js
+++ b/react-frontend/src/result/StatsBar.js
@@ -14,16 +14,17 @@ limitations under the License.
 */
 
 import * as React from 'react';
-import { MIGRATE_SETTINGS_2_0 } from '../backend/backend';
-import { useHandlePostCurrent } from '../backend/useHandlePost';
-import MigrateButton from './MigrateButton';
+import HorizontalStackedBar from '../extraction/HorizontalStackedBar';
+import { buildStatuses } from './ResultHook';
 
-export default function MigrateButtonUncontrolled({ handleChange, label, progressComponent = null, progress = "", confirm = false, runOnce = false, api = MIGRATE_SETTINGS_2_0 }) {
+export default function StatsBar({ stats }) {
 
-    const { handlePost } = useHandlePostCurrent(handleChange, api)
+    const statuses = React.useMemo(() => {
+        return buildStatuses(stats)
+    }, [stats])
 
     return (
-        <MigrateButton label={label} handlePost={handlePost} confirm={confirm} progressComponent={progressComponent} progress={progress} runOnce={runOnce} />
+        statuses == null ? null :
+            <HorizontalStackedBar id={'statistics'} statuses={statuses} onClickMenu={() => { }} />
     )
 }
-

--- a/react-frontend/src/result/TFAnsiText.js
+++ b/react-frontend/src/result/TFAnsiText.js
@@ -88,7 +88,6 @@ export default function TFAnsiText({ logList }) {
                 startLine = logList.length - 1
             }
 
-            console.log(page, startLine)
             for (let i = startLine; (i < logList.length && ansiLines.length < maxLines); i++) {
                 processLog(logList[i], (i + 1), searchText, ansiLines, changePageToLine, highlightLine, setHighlightLine);
             }

--- a/react-frontend/src/result/TFLog.js
+++ b/react-frontend/src/result/TFLog.js
@@ -16,19 +16,15 @@ limitations under the License.
 import { Paper, Typography } from '@mui/material';
 import * as React from 'react';
 import EfficientAccordion from './EfficientAccordion';
-import HorizontalStackedBar, { STATUS_COLORS } from '../extraction/HorizontalStackedBar';
+import { STATUS_COLORS } from '../extraction/HorizontalStackedBar';
 import TFAnsiText from './TFAnsiText';
 import { applyActionLabel } from './ResultDetailsHooks';
 import TFLogModule from './TFLogModule';
-import { buildStatuses } from './ResultHook';
+import StatsBar from './StatsBar';
 
 
 
 export default function TFLog({ historyItemLog: { modules: logs, other_lines: other, apply_complete, no_changes, stats }, actionLabel, actionId, defaultExpanded = false }) {
-
-    const statuses = React.useMemo(() => {
-        return buildStatuses(stats)
-    }, [stats])
 
     return (
         ((logs == null || Object.keys(logs).length === 0) && other == null) ? null :
@@ -42,8 +38,7 @@ export default function TFLog({ historyItemLog: { modules: logs, other_lines: ot
                     defaultExpanded={defaultExpanded}
                     componentList={
                         [
-                            statuses == null ? null :
-                                <HorizontalStackedBar id={'statistics'} statuses={statuses} onClickMenu={() => { }} />,
+                            <StatsBar stats={stats} />,
                             other == null ? null :
                                 <EfficientAccordion
                                     label="General execution info"

--- a/react-frontend/src/terraform/TerraformButton.js
+++ b/react-frontend/src/terraform/TerraformButton.js
@@ -20,10 +20,10 @@ import { useProgress } from '../progress/ProgressHook';
 
 export default function TerraformButton({ terraformParams, handleChange, getActionId, label, confirm, terraformAPI, disabled = false }) {
 
-    const { setLoading, progressComponent } = useProgress()
-    const handlePost = useHandlePostTerraform(terraformParams, handleChange, terraformAPI, getActionId, setLoading)
+    const { progress, setProgress, progressComponent } = useProgress()
+    const handlePost = useHandlePostTerraform(terraformParams, handleChange, terraformAPI, getActionId, setProgress)
 
     return (
-        <MigrateButton label={label} handlePost={handlePost} confirm={confirm} disabled={disabled} progressComponent={progressComponent} />
+        <MigrateButton label={label} handlePost={handlePost} confirm={confirm} disabled={disabled} progressComponent={progressComponent} progress={progress} />
     );
 }

--- a/react-frontend/src/wizard/WizExplained.js
+++ b/react-frontend/src/wizard/WizExplained.js
@@ -1,0 +1,55 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import { Box, Button, Typography } from '@mui/material';
+import * as React from 'react';
+import { MatrixBlue, MatrixRed, genMatrixButtonProps } from '../options/FirstTimeUser';
+import { useExecutionOptionsState } from '../context/ExecutionContext';
+
+export function WizExplained({ showNextTab }) {
+
+  const { setAdvancedMode, setFirstTimeUser } = useExecutionOptionsState()
+
+  const handleChangeAdvancedMode = (advancedMode) => {
+    setAdvancedMode(advancedMode)
+  }
+  const handleChangeFirstTimeUser = (firstTimeUser) => {
+    setFirstTimeUser(firstTimeUser)
+  }
+
+  const environment = process.env.REACT_APP_ENVIRONMENT;
+
+  return (
+    <React.Fragment>
+      <Box sx={{ ml: 4 }}>
+
+        <Typography variant='h6'>
+          Assisted mode purpose:
+        </Typography>
+        <Typography sx={{ ml: 2 }}>
+          - A faster, more streamlined way of using the tool.
+          <br /> - If you need more control, switch to advanced.
+        </Typography>
+        <Button sx={{ mx: 2, mt: 4 }} {...genMatrixButtonProps(MatrixBlue)} onClick={showNextTab}>Continue</Button>
+        <Button sx={{ mx: 2, mt: 4 }} {...genMatrixButtonProps(MatrixRed)} onClick={() => { handleChangeAdvancedMode(true) }}>Switch to Advanced</Button>
+        {environment !== "test" ? 
+        null
+        : <Button sx={{ mx: 2, mt: 4 }} {...genMatrixButtonProps("white")} disableElevation disableFocusRipple disableRipple onClick={() => { handleChangeFirstTimeUser(true) }}>Switch to First Time User (Dev only)</Button>
+        }
+      </Box>
+
+    </React.Fragment>
+  );
+}

--- a/react-frontend/src/wizard/WizRun.js
+++ b/react-frontend/src/wizard/WizRun.js
@@ -1,0 +1,295 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import { Box, Button, Grid, IconButton, Typography } from '@mui/material';
+import * as React from 'react';
+import { MatrixBlue, MatrixDisabled, MatrixRed, genMatrixButtonProps } from '../options/FirstTimeUser';
+import { useHandleExtractConfigs, useHandleExtractEntities } from '../extraction/ExtractionHooks';
+import { TENANT_KEY_TYPE_MAIN, TENANT_KEY_TYPE_TARGET, useTenant, useTenantKey } from '../context/TenantListContext';
+import { DONE, ERROR, LOADING, NOT_STARTED } from '../progress/ProgressHook';
+import ClearIcon from '@mui/icons-material/Clear';
+import CheckIcon from '@mui/icons-material/Check';
+import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
+import { useHandlePostProcess } from '../migrate/PostProcessHooks';
+import { useExecutionOptionsState } from '../context/ExecutionContext';
+import { useHandleApplyAll } from '../migrate/ApplyAllHooks';
+import StatsBar from '../result/StatsBar';
+
+export function WizRun({ showNextTab }) {
+
+
+  const { tenantKey: tenantKeySource } = useTenantKey(TENANT_KEY_TYPE_MAIN)
+  const { tenant: { label: labelSource } } = useTenant(tenantKeySource)
+
+  const { tenantKey: tenantKeyTarget } = useTenantKey(TENANT_KEY_TYPE_TARGET)
+  const { tenant: { label: labelTarget } } = useTenant(tenantKeyTarget)
+
+
+  const { enableDashboards, enableOmitDestroy, setEnableDashboards, setEnableOmitDestroy, setAdvancedMode } = useExecutionOptionsState()
+  React.useEffect(() => {
+    if (enableDashboards !== true) {
+      setEnableDashboards(true)
+      return
+    }
+    if (enableOmitDestroy !== true) {
+      setEnableOmitDestroy(true)
+      return
+    }
+  })
+
+  const { progress: progressConfigsSource, progressComponent: progressComponentConfigsSource, handleExtractConfigs: handleExtractConfigsSource } = useHandleExtractConfigs(tenantKeySource)
+  const { progress: progressConfigsTarget, progressComponent: progressComponentConfigsTarget, handleExtractConfigs: handleExtractConfigsTarget } = useHandleExtractConfigs(tenantKeyTarget)
+
+  const { progress: progressEntitiesSource, progressComponent: progressComponentEntitiesSource, handleExtractEntities: handleExtractEntitiesSource } = useHandleExtractEntities(tenantKeySource)
+  const { progress: progressEntitiesTarget, progressComponent: progressComponentEntitiesTarget, handleExtractEntities: handleExtractEntitiesTarget } = useHandleExtractEntities(tenantKeyTarget)
+
+  const { progress: progressPostProcess, progressComponent: progressComponentPostProcess, handlePostProcess, planStats } = useHandlePostProcess()
+  const { progress: progressApplyAll, progressComponent: progressComponentApplyAll, handleApplyAll, applyStats } = useHandleApplyAll()
+
+  const handleExtractPostProcess = React.useCallback(() => {
+    handleExtractConfigsSource()
+    handleExtractConfigsTarget()
+  }, [handleExtractConfigsSource, handleExtractConfigsTarget])
+
+  const handlePushAll = React.useCallback(() => {
+    handleApplyAll()
+  }, [handleExtractConfigsSource, handleExtractConfigsTarget])
+
+  const handleAdvanced = React.useCallback(() => {
+    setAdvancedMode(true)
+  }, [handleExtractConfigsSource, handleExtractConfigsTarget])
+
+  React.useEffect(() => {
+    if (progressConfigsSource === DONE && progressEntitiesSource === NOT_STARTED) {
+      handleExtractEntitiesSource()
+    }
+  }, [progressConfigsSource])
+
+  React.useEffect(() => {
+    if (progressConfigsTarget === DONE && progressEntitiesTarget === NOT_STARTED) {
+      handleExtractEntitiesTarget()
+    }
+  }, [progressConfigsTarget])
+
+  React.useEffect(() => {
+    if (progressEntitiesSource === DONE && progressEntitiesTarget === DONE && progressPostProcess === NOT_STARTED) {
+      handlePostProcess()
+    }
+  }, [progressEntitiesSource, progressEntitiesTarget])
+
+  const [prepareButtonColor, prepareButtonMessage, prepareButtonDisabled] = React.useMemo(() => {
+    const disabled = progressConfigsSource !== NOT_STARTED || progressConfigsTarget !== NOT_STARTED
+    if (disabled) {
+      if (progressPostProcess === DONE) {
+        return [MatrixDisabled, "Completed", disabled]
+      } else {
+        return [MatrixDisabled, "Running. this could take a while...", disabled]
+      }
+    }
+    return [MatrixBlue, "Run the extraction and post-processing phases", disabled]
+  }, [progressConfigsSource, progressConfigsTarget, progressPostProcess])
+
+  const [pushAllButtonColor, pushAllButtonMessage, pushAllButtonDisabled] = React.useMemo(() => {
+    if (progressPostProcess === DONE) {
+      if (progressApplyAll === NOT_STARTED) {
+        return [MatrixBlue, "Push all configs", false]
+      } else if (progressApplyAll === DONE) {
+        return [MatrixDisabled, "Completed", true]
+      } else {
+        return [MatrixDisabled, "Running. this could take a while...", true]
+      }
+    }
+    return [MatrixDisabled, "Push all configs", true]
+  }, [progressPostProcess, progressApplyAll])
+
+  const [advancedButtonColor, advancedButtonMessage, advancedButtonDisabled] = React.useMemo(() => {
+    if (progressPostProcess === DONE) {
+      if (progressApplyAll === NOT_STARTED) {
+        return [MatrixRed, "Switch to advanced", false]
+      } else {
+        return [MatrixDisabled, "Switch to advanced", true]
+      }
+    }
+    return [MatrixDisabled, "Switch to advanced", true]
+  }, [progressPostProcess, progressApplyAll])
+
+  const [advanced2ButtonColor, advanced2ButtonMessage, advanced2ButtonDisabled] = React.useMemo(() => {
+    if (progressApplyAll === DONE) {
+      return [MatrixRed, "Switch to advanced", false]
+    }
+    return [MatrixDisabled, "Switch to advanced", true]
+  }, [progressApplyAll])
+
+  return (
+    <React.Fragment>
+      <Typography sx={{ ml: 4 }} variant="h6">
+        Source: {labelSource}
+      </Typography>
+      <Typography sx={{ ml: 4, mb: 2 }} variant="h6">
+        Target: {labelTarget}
+      </Typography>
+
+      {progressApplyAll !== NOT_STARTED ? null
+        : (
+          <Grid container>
+            <Grid item xs={6}>
+              <Box sx={{ ml: 4 }}>
+                <Button {...genMatrixButtonProps(prepareButtonColor)} disabled={prepareButtonDisabled} onClick={handleExtractPostProcess}>{prepareButtonMessage}</Button>
+                {genStatusComponent(progressConfigsSource, progressComponentConfigsSource, "Extract source tenant configs")}
+                {genStatusComponent(progressConfigsTarget, progressComponentConfigsTarget, "Extract target tenant configs")}
+                {genStatusComponent(progressEntitiesSource, progressComponentEntitiesSource, "Extract source tenant entities")}
+                {genStatusComponent(progressEntitiesTarget, progressComponentEntitiesTarget, "Extract target tenant entities")}
+                {genStatusComponent(progressPostProcess, progressComponentPostProcess, "Post-Process the extracted data")}
+              </Box>
+            </Grid>
+            <Grid item xs={5}>
+              <Box sx={{ ml: 4 }}>
+                <Typography variant='h6'>
+                  Migration of configs:
+                </Typography>
+                <Typography sx={{ ml: 2 }}>
+                  This is a complex multiple step action
+                  <br /> Depending on the size of tenants, it could take a while.
+                  <br /> <br /> 1. Create the cache:
+                </Typography>
+                <Typography sx={{ ml: 4 }}>
+                  - Extract entities from both tenants
+                  <br /> - Extract configs from both tenants
+                </Typography>
+                <Typography sx={{ ml: 2 }}>
+                  <br /> 2. Work on the cache to prepare for migration (post-process):
+                </Typography>
+                <Typography sx={{ ml: 4 }}>
+                  - Match entity IDs that may have changed
+                  <br /> - Replace Source entity IDs with Target IDs
+                  <br /> - Create terraform state for Target tenant
+                  <br /> - Create terraform resource files for Source tenant
+                  <br /> - Run a terraform Plan to understand differences
+                </Typography>
+              </Box>
+            </Grid>
+          </Grid>
+        )}
+      {progressPostProcess !== DONE ? null
+        : (
+          <Grid sx={{ mt: 6 }} container>
+            <Grid item xs={6}>
+              <Box sx={{ ml: 4 }}>
+                <Typography color="black" variant={"h6"}>Status prior to migration</Typography>
+                <StatsBar stats={planStats} />
+                <Typography sx={{ ml: 2 }}>
+                  <br /> Push <b>All</b> configs will prepare your Target tenant for a migration
+                  <br /> Or help complete configs after entities are migrated
+                </Typography>
+                <Typography sx={{ ml: 4 }}>
+                  - If you need more control, switch to Advanced mode and go to the Manage Configs Tab.
+                  <br /> - You will always be able to change between modes.
+                </Typography>
+                <Button sx={{ mx: 2, mt: 4 }} {...genMatrixButtonProps(pushAllButtonColor)} disabled={pushAllButtonDisabled} onClick={handlePushAll}>{pushAllButtonMessage}</Button>
+                {progressApplyAll !== NOT_STARTED ?
+                  null
+                  :
+                  <Button sx={{ mx: 2, mt: 4 }} {...genMatrixButtonProps(advancedButtonColor)} disabled={advancedButtonDisabled} onClick={handleAdvanced}>{advancedButtonMessage}</Button>
+                }
+                {genStatusComponent(progressApplyAll, progressComponentApplyAll, "Push all configs")}
+              </Box>
+            </Grid>
+            <Grid item xs={5}>
+              <Box sx={{ ml: 4 }}>
+                <Typography sx={{ ml: 2 }}>
+                  3. Push configs:
+                </Typography>
+                <Typography sx={{ ml: 4 }}>
+                  - Run a terraform Apply
+                </Typography>
+                <Typography sx={{ ml: 2 }}>
+                  <br /> Note 1: Configs can and will be pushed BEFORE the entities are migrated.
+                  <br /> <br /> Note 2: After migration, some entities will be given a different ID in the Target tenant.
+                </Typography>
+                <Typography sx={{ ml: 4 }}>
+                  - There are ways to mitigate, but it will always happen.
+                  <br /> - Running this tool after migrating entities will help you avoid missing configs.
+                </Typography>
+              </Box>
+            </Grid>
+          </Grid>
+        )}
+      {progressApplyAll !== DONE ? null
+        : (
+          <Grid sx={{ mt: 6 }} container>
+            <Grid item xs={6}>
+              <Box sx={{ ml: 4 }}>
+                <Typography color="black" variant={"h6"}>Status post migration</Typography>
+                <StatsBar stats={applyStats} />
+                <Typography sx={{ ml: 2 }}>
+                  <br /> You can now see the results of the migration
+                </Typography>
+                <Typography sx={{ ml: 4 }}>
+                  - For now, the assisted mode only provides statistics
+                  <br /> - If you want to see more details, switch to Advanced mode and go to the Manage Configs Tab.
+                  <br /> - You will always be able to change between modes.
+                </Typography>
+                <Button sx={{ mx: 2, mt: 4 }} {...genMatrixButtonProps(advanced2ButtonColor)} disabled={advanced2ButtonDisabled} onClick={handleAdvanced}>{advanced2ButtonMessage}</Button>
+              </Box>
+            </Grid>
+            <Grid item xs={5}>
+              <Box sx={{ ml: 4 }}>
+              </Box>
+            </Grid>
+          </Grid>
+        )}
+    </React.Fragment>
+  );
+}
+
+function genStatusComponent(progress, progressComponent, label) {
+  let statusComponent = null
+
+  if (progress === NOT_STARTED) {
+    statusComponent = (
+      <IconButton color={MatrixDisabled} disableFocusRipple disableRipple disableElevation>
+        <PlayCircleOutlineIcon color={MatrixDisabled} fontSize="large" />
+        <Typography>{label}</Typography>
+      </IconButton>
+    )
+  } else if (progress === LOADING) {
+    statusComponent = (
+      <IconButton color="primary" disableFocusRipple disableRipple disableElevation>
+        {progressComponent}
+        <Typography>{label}</Typography>
+      </IconButton>
+    )
+  } else if (progress === ERROR) {
+    statusComponent = (
+      <IconButton color="error" disableFocusRipple disableRipple disableElevation>
+        <ClearIcon color="error" fontSize="large" />
+        <Typography>{label}</Typography>
+      </IconButton>
+    )
+  } else if (progress === DONE) {
+    statusComponent = (
+      <IconButton color="success" disableFocusRipple disableRipple disableElevation>
+        <CheckIcon color="success" fontSize="large" />
+        <Typography>{label}</Typography>
+      </IconButton>
+    )
+  }
+
+  return (
+    <Box>
+      {statusComponent}
+    </Box>
+  )
+}

--- a/react-frontend/src/wizard/WizRunPage.js
+++ b/react-frontend/src/wizard/WizRunPage.js
@@ -14,16 +14,20 @@ limitations under the License.
 */
 
 import * as React from 'react';
-import { MIGRATE_SETTINGS_2_0 } from '../backend/backend';
-import { useHandlePostCurrent } from '../backend/useHandlePost';
-import MigrateButton from './MigrateButton';
+import MigrateContext from '../context/components/MigrateContext';
+import MigrateContextLoad from '../context/components/MigrateContextLoad';
+import { WizRun } from './WizRun';
 
-export default function MigrateButtonUncontrolled({ handleChange, label, progressComponent = null, progress = "", confirm = false, runOnce = false, api = MIGRATE_SETTINGS_2_0 }) {
+export function WizRunPage({ showNextTab }) {
 
-    const { handlePost } = useHandlePostCurrent(handleChange, api)
-
-    return (
-        <MigrateButton label={label} handlePost={handlePost} confirm={confirm} progressComponent={progressComponent} progress={progress} runOnce={runOnce} />
-    )
+  return (
+    <React.Fragment>
+      <MigrateContext>
+        <MigrateContextLoad>
+          <WizRun showNextTab={showNextTab} />
+        </MigrateContextLoad>
+      </MigrateContext>
+    </React.Fragment>
+  );
 }
 

--- a/react-frontend/src/wizard/WizTenantConfig.js
+++ b/react-frontend/src/wizard/WizTenantConfig.js
@@ -1,0 +1,168 @@
+/*
+Copyright 2023 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/
+
+import { Box, Button, Grid, Typography } from '@mui/material';
+import * as React from 'react';
+import TenantConfigBasics from '../credentials/TenantConfigBasics';
+import { MatrixBlue, MatrixDisabled, MatrixRed, genMatrixButtonProps } from '../options/FirstTimeUser';
+import { TENANT_KEY_TYPE_MAIN, TENANT_KEY_TYPE_TARGET, useTenant, useTenantKey } from '../context/TenantListContext';
+import TenantConfigConnectionOptions from '../credentials/TenantConfigConnectionOptions';
+import TenantSelector from '../credentials/TenantSelector';
+import AddTenantButton from '../credentials/AddTenantButton';
+
+const TenantLabel = {
+  [TENANT_KEY_TYPE_MAIN]: "Source",
+  [TENANT_KEY_TYPE_TARGET]: "Target",
+}
+
+const TenantDescription = {
+  [TENANT_KEY_TYPE_MAIN]: "Tenant from which you will pull configurations",
+  [TENANT_KEY_TYPE_TARGET]: "Tenant where you configs will end up",
+}
+
+
+export function WizTenantConfig({ showNextTab, tenantKeyType = TENANT_KEY_TYPE_MAIN }) {
+  const { tenantKey } = useTenantKey(tenantKeyType)
+  const { tenant: { url, APIKey, connectionTested, disableSystemProxies, proxyURL } } = useTenant(tenantKey)
+  const { tenantKey: tenantKeySource } = useTenantKey(TENANT_KEY_TYPE_MAIN)
+  const { tenant: { label: labelSource } } = useTenant(tenantKeySource)
+  const [needsProxy, setNeedsProxy] = React.useState(false)
+
+  const [buttonColor, buttonMessage, buttonDisabled] = React.useMemo(() => {
+    if (connectionTested === true) {
+      return [MatrixBlue, `Done with ${TenantLabel[tenantKeyType]} Credentials`, false]
+    } else if (connectionTested === false) {
+      return [MatrixRed, "Move on with a failed connection test", false]
+    } else {
+      return [MatrixDisabled, "Please test the connection", true]
+    }
+  }, [connectionTested, tenantKeyType])
+
+  React.useEffect(() => {
+    let areProxySettingsAlreadySet = false
+    if ((disableSystemProxies === undefined || disableSystemProxies === false)
+      && (proxyURL === undefined || proxyURL === "")) {
+      // pass
+    } else {
+      areProxySettingsAlreadySet = true
+    }
+
+    if (needsProxy === true) {
+      if (areProxySettingsAlreadySet) {
+        return
+      } else if (connectionTested === true) {
+        setNeedsProxy(false)
+        return
+      }
+    }
+    if (areProxySettingsAlreadySet) {
+      setNeedsProxy(true)
+      return
+    }
+    if (url === "" || APIKey === "") {
+      return
+    }
+    if (connectionTested === false) {
+      setNeedsProxy(true)
+      return
+    }
+  }, [url, APIKey, connectionTested, disableSystemProxies, proxyURL, needsProxy, setNeedsProxy])
+
+  const isTargetSameAsSource = React.useMemo(() => {
+    if (tenantKeyType === TENANT_KEY_TYPE_TARGET
+      && tenantKey === tenantKeySource) {
+      return true
+    } else {
+      return false
+    }
+  }, [tenantKeyType, tenantKey, tenantKeySource])
+
+  return (
+    <React.Fragment>
+      <Grid container>
+        <Grid item xs={6}>
+          <Box sx={{ ml: 4 }}>
+            {tenantKeyType !== TENANT_KEY_TYPE_TARGET ?
+              null
+              : <Typography sx={{ mb: 2 }} variant="h6">
+                Source: {labelSource}
+              </Typography>
+            }
+            <TenantSelector tenantKeyType={tenantKeyType} />
+            <AddTenantButton tenantKeyType={tenantKeyType} />
+          </Box>
+        </Grid>
+      </Grid>
+      {isTargetSameAsSource ?
+        <Typography variant='h6'><br /> Please make sure the Source and Target tenant are different.</Typography>
+        : (
+          <React.Fragment>
+            <Grid container>
+              <Grid item xs={6}>
+                <Box sx={{ ml: 4 }}>
+                  <TenantConfigBasics tenantKeyType={tenantKeyType} />
+                </Box>
+              </Grid>
+              <Grid item xs={5}>
+                <Box sx={{ ml: 4 }}>
+
+                  <Typography variant='h6'>
+                    {TenantLabel[tenantKeyType]} Tenant Credentials:
+                  </Typography>
+                  <Typography sx={{ ml: 2 }}>
+                    {TenantLabel[tenantKeyType]}  tenant: {TenantDescription[tenantKeyType]}
+                    <br /> Please provide the required information below:
+                  </Typography>
+                  <Typography sx={{ ml: 4 }}>
+                    - Label or name
+                    <br /> - Url
+                    <br /> - APIKey
+                  </Typography>
+                  <Typography sx={{ ml: 2 }}>
+                    When you are done, make sure you Test the Connection
+                  </Typography>
+                </Box>
+              </Grid>
+            </Grid>
+            {!needsProxy ?
+              null
+              : (<Grid container sx={{ mt: 4 }}>
+                <Grid item xs={6}>
+                  <Box sx={{ ml: 4 }}>
+                    <TenantConfigConnectionOptions tenantKeyType={tenantKeyType} />
+                  </Box>
+                </Grid>
+                <Grid item xs={5}>
+                  <Box sx={{ ml: 4 }}>
+                    <Typography variant='h6'>Additional connection settings could be required</Typography>
+                  </Box>
+                </Grid>
+              </Grid>
+              )}
+            <Grid container sx={{ mt: 4 }}>
+              <Grid item xs={6}>
+                <Box sx={{ ml: 4 }}>
+                  <Button {...genMatrixButtonProps(buttonColor)} disabled={buttonDisabled} onClick={showNextTab}>{buttonMessage}</Button>
+                </Box>
+
+              </Grid>
+              <Grid item xs={5}></Grid>
+            </Grid>
+          </React.Fragment>
+        )
+      }
+    </React.Fragment >
+  );
+}

--- a/react-frontend/src/wizard/WizardPage.js
+++ b/react-frontend/src/wizard/WizardPage.js
@@ -13,20 +13,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { Grid, Typography } from '@mui/material';
 import * as React from 'react';
-import DocumAPIToken from './DocumAPIToken';
-import TabPanelBar, { genTabConfig } from '../navigation/TabPanelBar';
+import TabPanelAssisted from '../navigation/TabPanelAssisted';
 
+export function WizardPage(props) {
+  const [tabIdx, setTabIdx] = React.useState(0);
 
-const tabConfig = [
-    genTabConfig("Access Tokens", <DocumAPIToken />),
-]
-
-export default function DocumPanel() {
-    const [tabIdx, setTabIdx] = React.useState(0);
-
-    return (
-        <TabPanelBar tabConfig={tabConfig} tabIdx={tabIdx} setTabIdx={setTabIdx} />
-    )
+  return (
+    <React.Fragment>
+      <Grid item sx={{ mt: 2, mb: 1 }} direction={"column"} align={'center'}>
+        <Typography variant='h4'>
+          Assisted Config Migration
+        </Typography>
+      </Grid>
+      <TabPanelAssisted tabIdx={tabIdx} setTabIdx={setTabIdx} />
+    </React.Fragment>
+  );
 }
-


### PR DESCRIPTION
Refresh status really means Done
Retry loading the tenant_list, concurrent read/write problem Create the Assisted mode
Show buttons as errors (red) when possible
First time user splash page
handle connection testing better for assisted mode Split tenantConfig component
No more connection test label
Show docum API in tenant config basics
Minor refactor  for most calls to backend